### PR TITLE
Also look in `Graphviz/lib/` on windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,10 +2,7 @@ use std::fs::read_dir;
 
 fn main() {
     let dirs = read_dir("C:\\Program Files (x86)\\")
-        .and_then(|dirs| {
-            read_dir("C:\\Program Files\\")
-                .map(|dirs2| dirs.chain(dirs2))
-        });
+        .and_then(|dirs| read_dir("C:\\Program Files\\").map(|dirs2| dirs.chain(dirs2)));
     if let Ok(dirs) = dirs {
         for entry in dirs {
             if let Ok(entry) = entry {
@@ -13,6 +10,7 @@ fn main() {
                     if file.starts_with("Graphviz") {
                         let path = entry.path();
                         if let Some(path) = path.to_str() {
+                            println!("cargo:rustc-link-search={}\\lib", path);
                             println!("cargo:rustc-link-search={}\\lib\\debug\\lib", path);
                         }
                     }


### PR DESCRIPTION
This fixed building priroda on Windows for me

However, I still needed `...Graphviz/bin` in my PATH, which doesn't quite seem right since 158abf6ee35405fc23867913dd421cf531a1bfec claimed to use static linking

It's possible that this change is doing nothing, and something else is breaking static linking on WIndows.